### PR TITLE
update the dmi_collector to distinguish between the system being a VM or not

### DIFF
--- a/src/collectors/dmi_collector.rs
+++ b/src/collectors/dmi_collector.rs
@@ -26,6 +26,7 @@ pub struct SystemInformation {
     model: String,
     uuid: String,
     serial: String,
+    is_virtual: bool,
 }
 
 #[derive(Debug)]
@@ -83,6 +84,10 @@ fn dmidecode_system() -> SystemInformation {
      * provides.
      * The output is processed and the required information is extracted from the string and saved into a
      * system_information instance.
+     *
+     * If the vendor found is QEMU it is assumed that the machine is a virtual machine.
+     * This is important as Virtual Machines and Physical Machines are treated differently by NetBox and registered at
+     * different URLs.
      * */
     let output: String = execute_dmidecode(1);
     let output_split: Split<'_, &str> = output.split("\n");
@@ -93,6 +98,7 @@ fn dmidecode_system() -> SystemInformation {
         model: String::new(),
         uuid: String::new(),
         serial: String::new(),
+        is_virtual: false,
     };
 
     let mut table_found: bool = false;
@@ -127,6 +133,10 @@ fn dmidecode_system() -> SystemInformation {
         match key.as_str() {
             "Manufacturer" => {
                 system_information.vendor = value.trim().to_string();
+
+                if system_information.vendor == "QEMU" {
+                    system_information.is_virtual = true;
+                }
             }
             "Product Name" => {
                 system_information.model = value.trim().to_string();


### PR DESCRIPTION
# What does this PR change?

This PR puts in a small check if the Vendor of a given system is `QEMU`. If it is the system is marked as being a VM.

<!-- provide a short description what exactly your PR changes here -->

Tick the applicable box:
- [x] Add new feature
- [ ] Add language support
- [ ] Security changes
- [ ] Tests
- [ ] Documentation changed
<br/>

- [ ] General Maintenance

## Links

<!-- In case your changes fix an existing issue please link it below: -->

Fixes: N/A

- [x] DONE

## Documentation

<!-- provide description about documentation done here or remove this line -->

- No documentation needed
<br/>

- [x] DONE