### PR TITLE
[CI:] Add cargo audit for dependency vulnerability scanning

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,26 @@
+name: Dependency Vulnerability Audit
+
+on:
+    push:
+      branches:
+        - main
+    pull_request:
+      branches:
+        - main
+    schedule:
+        - cron: '0 0 * * 0'
+
+jobs:
+    vulnerability_audit:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions-rs/toolchain@v1
+              with:
+                toolchain: stable
+                override: true
+            - uses: actions/cargo@v1
+              with:
+                use-cross: true
+                command: audit
+                args: --color always

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -19,7 +19,7 @@ jobs:
               with:
                 toolchain: stable
                 override: true
-            - uses: actions/cargo@v1
+            - uses: actions-rs/cargo@v1
               with:
                 use-cross: true
                 command: audit


### PR DESCRIPTION
# What does this PR change?

<!-- provide a short description what exactly your PR changes here -->

This PR adds a new workflow which uses the `cargo audit` module to automatically scan the `cargo.lock` file for reported vulnerabilities within the used dependencies.

While Dependabot is active for Netbox Sync, `cargo audit` accesses a database specifically with vulnerability reports for Rust dependencies and having multiple layers of audits to me seems like a good idea.

Tick the applicable box:
- [ ] Add new feature
- [x] Security changes
- [ ] Tests
- [ ] Documentation changed
<br/>

- [x] General Maintenance

## Links

<!-- In case your changes fix an existing issue please link it below: -->

Fixes: N/A

- [x] DONE

## Documentation

<!-- provide description about documentation done here or remove this line -->

- No documentation needed
<br/>

- [x] DONE