### PR TITLE
Rewrite `dmi_collector`

### DIFF
--- a/src/collectors/dmi_collector.rs
+++ b/src/collectors/dmi_collector.rs
@@ -384,3 +384,49 @@ fn dmidecode_cpu() -> CpuInformation {
     println!("\x1b[32mSuccess:\x1b[0m CPU information collection completed.");
     return cpu_information;
 }
+
+#[cfg(test)]
+pub mod dmi_collector_tests {
+    use super::*;
+    use std::any::Any;
+
+    /// Check a given value's type for being String or not.
+    ///
+    /// ## Returns
+    ///
+    /// * `bool` - True/False depending on if the given value is a String type.
+    fn is_string(value: &dyn Any) -> bool {
+        value.is::<String>()
+    }
+
+    /// Tests whether the `get_dmidecode_information` function panics when it tries to execute `dmidecode -s` with an
+    /// invalid parameter.
+    #[test]
+    #[should_panic]
+    fn test_get_dmidecode_information_panics() {
+        let result: Result<String, Box<dyn Any + Send>> =
+            std::panic::catch_unwind(|| get_dmidecode_information("invalid"));
+
+        assert!(
+            result.is_err(),
+            "Test failure: get_dmidecode_information did not panic when supplied with an invalid
+        argument"
+        );
+    }
+
+    /// Test that `get_dmidecode_information` does not return an empty String. Validating that the given parameter is
+    /// valid.
+    #[test]
+    fn test_get_dmidecode_information_ok() {
+        let result: String = get_dmidecode_information("system-manufacturer");
+
+        assert!(
+            is_string(&result),
+            "Test failure: get_dmidecode_information did not return a String type!"
+        );
+        assert!(
+            !result.is_empty(),
+            "Test failure: get_dmidecode_information did return an empty string despite supplying a valid parameter!"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ mod collectors;
 use collectors::{dmi_collector, network_collector};
 
 fn main() {
-    let output: dmi_collector::DmiInformation = dmi_collector::dmidecode();
+    let output: dmi_collector::DmiInformation = dmi_collector::construct_dmi_information();
     println!("{:#?}", output);
 
     let output2 = network_collector::construct_network_information();


### PR DESCRIPTION
# What does this PR change?

<!-- provide a short description what exactly your PR changes here -->

This PR implements a new `get_dmi_information` function which takes a `&str` parameter and executes `dmidecode -s <PARAMETER>` and returns the Output as a String.

This helps minimizing our previous ugly String handling code and avoid crawling throght the tables returned by `dmidecode`.
The aforementioned string handling is still required for the `CPUInformation` as stats like the amount of enabled/disabled cores, voltage or socket population cannot be delivered by using the `-s` flag. However it makes the code much more readable and more maintainable for the future as no excessive String handling is necessary to collect the basic system and chassis information.

TODO:
- [x] Implement Unittests for these functions if applicable. ( Writing unittest for this may be complicated by the execution of dmidecode requiring root privileges)

Tick the applicable box:
- [ ] Add new feature
- [ ] Security changes
- [x] Tests
- [ ] Documentation changed
<br/>

- [x] General Maintenance

## Links

<!-- In case your changes fix an existing issue please link it below: -->

Fixes: #10 

- [x] DONE

## Documentation

<!-- provide description about documentation done here or remove this line -->

- Documentation provided as function and module docstrings, can be built with cargo docs.
<br/>

- [x] DONE