### PR TITLE
Add basic CLI for configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "4.4.2", features = ["derive"] }
 network-interface = "1.0.1"
 serde = { version = "1.0.188", features = ["derive"] }
 toml = "0.7.6"

--- a/src/configuration/config_parser.rs
+++ b/src/configuration/config_parser.rs
@@ -27,7 +27,24 @@ pub struct ConfigData {
 }
 
 /// Set up configuration
-pub fn set_up_configuration() -> Result<ConfigData, String> {
+///
+/// This function reads the configuration file located at `~/.nbs-config.toml`. If no file can be found, a warning is
+/// displayed to the user and a default config file is written.
+/// If command line arguments are given, the parameters read from the file will be overwritten.
+///
+/// # Returns
+///
+/// * `Ok(ConfigData)` - A `ConfigData` object containing the netbox URI and API token.
+/// * `Err` - Prints an Error if the file cannot be validated.
+///
+/// # Panics
+///
+/// The function panics under these condition:
+///
+/// * If the initialization of the config file raises an error.
+/// * When using a default (empty) configuration file and not providing all required CLI arguments.
+/// * If the configuration file cannot be read.
+pub fn set_up_configuration(uri: String, token: String) -> Result<ConfigData, String> {
     let conf_data: ConfigData;
 
     println!("Checking for existing configuration file...");
@@ -52,6 +69,13 @@ pub fn set_up_configuration() -> Result<ConfigData, String> {
             Err(_) => {
                 panic!("FATAL: An error occurred while initializing the config!")
             }
+        }
+
+        if uri.is_empty() || token.is_empty() {
+            panic!(
+                "FATAL: No configuration parameters found in CLI while using an empty config file!\n
+                Please enter valid configuration parameters in the configuration file or provide them via the CLI."
+            )
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,17 +24,17 @@ use configuration::config_parser::set_up_configuration;
 struct Args {
     /// URI to your Netbox instance
     #[arg(short, long)]
-    uri: String,
+    uri: Option<String>,
 
     /// Your API authentication token
     #[arg(short, long)]
-    token: String,
+    token: Option<String>,
 }
 
 fn main() {
     let args: Args = Args::parse();
 
-    println!("Uri: {}\nToken: {}", args.uri, args.token);
+    // println!("Uri: {}\nToken: {}", args.uri.clone().unwrap(), args.token.clone().unwrap());
 
     let output: dmi_collector::DmiInformation = dmi_collector::construct_dmi_information();
     println!("{:#?}", output);

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,6 @@ use clap::Parser;
 use collectors::{dmi_collector, network_collector};
 use configuration::config_parser::set_up_configuration;
 
-
 /// The arguments that netbox-sync expects to get via the cli.
 ///
 /// Arguments can be passed like this:
@@ -37,7 +36,6 @@ fn main() {
 
     println!("Uri: {}\nToken: {}", args.uri, args.token);
 
-
     let output: dmi_collector::DmiInformation = dmi_collector::construct_dmi_information();
     println!("{:#?}", output);
 
@@ -45,7 +43,7 @@ fn main() {
 
     println!("{:#?}", output2);
 
-    let config = match set_up_configuration() {
+    let config = match set_up_configuration(args.uri, args.token) {
         Ok(conf) => conf,
         Err(err) => {
             panic!("{}", err)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,43 @@
 mod collectors;
 pub mod configuration;
 
+use clap::Parser;
 use collectors::{dmi_collector, network_collector};
 use configuration::config_parser::set_up_configuration;
 
+
+/// The arguments that netbox-sync expects to get via the cli.
+///
+/// Arguments can be passed like this:
+///
+/// ```
+/// netbox-sync --uri <NETBOX_URI> --token <NETBOX_TOKEN>
+/// ```
+///
+/// These arguments override the ones defined in the `.nbs-config.toml`.
+///
+/// # Members
+///
+/// * `uri: String` - The URI to your Netbox instance.
+/// * `token: String` - The authentication token for the netbox URI.
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about=None)]
+struct Args {
+    /// URI to your Netbox instance
+    #[arg(short, long)]
+    uri: String,
+
+    /// Your API authentication token
+    #[arg(short, long)]
+    token: String,
+}
+
 fn main() {
+    let args: Args = Args::parse();
+
+    println!("Uri: {}\nToken: {}", args.uri, args.token);
+
+
     let output: dmi_collector::DmiInformation = dmi_collector::construct_dmi_information();
     println!("{:#?}", output);
 


### PR DESCRIPTION
# What does this PR change?

<!-- provide a short description what exactly your PR changes here -->

This PR adds a very rudimentary CLI using the [`clap`](https://docs.rs/clap/latest/clap/) crate.

This CLI enforces the use of at least two arguments:

```
netbox-sync --uri <NETBOX_URI> --token <NETBOX_API_TOKEN>
```

TODO:

- [x] Accept (optional) `uri` and `token` arguments (string) from the CLI.
- [x] Pass arguments on to the `config_parser` module.
- [x] Overwrite the parameters read from the configuration file in the `conf_data` object.
- [x] Error handling: If no config file exists and no arguments are passed -> exit.

**Hint:** The panic on an empty config file is in the `main.rs` and will change when the CLI is fully fleshed out. Until now, we need to fill the config file with something so it doesn't.

Furthermore planned are these two options:

* `--no-config` : Do NOT write a default config file and rely on the two arguments (may also be `--write-config`)
* `--set-config <URI> <TOKEN>`: Overwrite the two config parameters in the config file.

Tick the applicable box:
- [x] Add new feature
- [ ] Security changes
- [ ] Tests
- [ ] Documentation changed
<br/>

- [ ] General Maintenance

## Links

<!-- In case your changes fix an existing issue please link it below: -->

Fixes: #22 

- [x] DONE

## Documentation

<!-- provide description about documentation done here or remove this line -->

- Documentation provided by buildable docstrings.
<br/>

- [x] DONE