### PR TITLE
Add system location to configuration file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,10 @@ struct Args {
     /// Your API authentication token
     #[arg(short, long)]
     token: Option<String>,
+
+    /// The location of the machine (must be one of the locations you have set as available in your Netbox instance)
+    #[arg(short, long)]
+    location: Option<String>,
 }
 
 fn main() {
@@ -43,7 +47,7 @@ fn main() {
 
     println!("{:#?}", output2);
 
-    let config = match set_up_configuration(args.uri, args.token) {
+    let config = match set_up_configuration(args.uri, args.token, args.location) {
         Ok(conf) => conf,
         Err(err) => {
             panic!("{}", err)


### PR DESCRIPTION
# What does this PR change?

<!-- provide a short description what exactly your PR changes here -->

As the Netbox API requires a location for the system that is to be registered, we need to be able to hand netbox-sync this property.
With this PR the user can either enter this property via a `-l / --language` flag or specify it in the config file.

An example of this config file would be:

```toml
[netbox]
netbox_api_token = "netbox.company.de"
netbox_uri = "drrth429rthj894ghhkdjfhwlgz48g3hjhvjgerg34"

[system]
system_location = "Berlin"
```

Tick the applicable box:
- [x] Add new feature
- [ ] Security changes
- [ ] Tests
- [ ] Documentation changed
<br/>

- [ ] General Maintenance

## Links

<!-- In case your changes fix an existing issue please link it below: -->

Fixes: #31 

- [x] DONE

## Documentation

<!-- provide description about documentation done here or remove this line -->

- No documentation needed
<br/>

- [x] DONE