### PR TITLE
Error Handling: gracefully exit upon error

### DIFF
--- a/src/collectors/collector_exceptions.rs
+++ b/src/collectors/collector_exceptions.rs
@@ -1,7 +1,7 @@
 //! ## Collector Exception Module
 //!
 //! This module provides exceptions to the information collectors.
-use std::fmt;
+use std::{fmt, process};
 
 /// This error handles general errors with collecting information.
 ///
@@ -19,8 +19,9 @@ impl fmt::Display for UnableToCollectDataError {
 }
 
 impl UnableToCollectDataError {
-    pub fn panic(&self) -> ! {
-        panic!("{}", self)
+    pub fn abort(&self) -> ! {
+        println!("{}", self);
+        process::exit(1)
     }
 }
 
@@ -40,8 +41,9 @@ impl fmt::Display for InvalidNetworkInterfaceError {
 }
 
 impl InvalidNetworkInterfaceError {
-    pub fn panic(&self) -> ! {
-        panic!("{}", self)
+    pub fn abort(&self) -> ! {
+        println!("{}", self);
+        process::exit(1)
     }
 }
 

--- a/src/collectors/collector_exceptions.rs
+++ b/src/collectors/collector_exceptions.rs
@@ -1,9 +1,29 @@
-//! ## Collector Exception Module
+//! # Collector Exception Module
 //!
 //! This module provides exceptions to the information collectors.
+//!
+//! ## Error Codes
+//!
+//! We use custom error codes to help with the identification of problems.
+//!
+//! The config module uses error codes in the range of 20 - 29.
+//!
+//! |Code  |Name       |Explanation|
+//! |------|-----------|-----------|
+//! |`20`  |||
+//! |`21`  |||
+//! |`22`  |||
+//! |`23`  |||
+//! |`24`  |||
+//! |`25`  |||
+//! |`26`  |||
+//! |`27`  |||
+//! |`28`  |||
+//! |`29`  |||
+//!
 use std::{fmt, process};
 
-/// This error handles general errors with collecting information.
+/// Handles general errors with collecting information.
 ///
 /// Either because the command is unavailable, requires sudo privileges or other failures.
 ///

--- a/src/collectors/collector_exceptions.rs
+++ b/src/collectors/collector_exceptions.rs
@@ -8,18 +8,18 @@
 //!
 //! The config module uses error codes in the range of 20 - 29.
 //!
-//! |Code  |Name       |Explanation|
-//! |------|-----------|-----------|
-//! |`20`  |||
-//! |`21`  |||
-//! |`22`  |||
-//! |`23`  |||
-//! |`24`  |||
-//! |`25`  |||
-//! |`26`  |||
-//! |`27`  |||
-//! |`28`  |||
-//! |`29`  |||
+//! |Code  |Name       |Explanation                  |
+//! |------|-----------|-----------------------------|
+//! |`20`  |DmiError   |Unable to execute `dmidecode`|
+//! |`21`  |UnableToCollectDataError|Unspecified Error with data collection. Usually appears when subprocess fails or an output is malformed.|
+//! |`22`  |--Undefined--|--Undefined--|
+//! |`23`  |--Undefined--|--Undefined--|
+//! |`24`  |--Undefined--|--Undefined--|
+//! |`25`  |InvalidNetworkInterfaceError|Unable to identify a Network Interface as such.|
+//! |`26`  |NoNetworkInterfacesException|Unable to find any Network Interfaces.|
+//! |`27`  |--Undefined--|--Undefined--|
+//! |`28`  |--Undefined--|--Undefined--|
+//! |`29`  |--Undefined--|--Undefined--|
 //!
 use std::{fmt, process};
 

--- a/src/collectors/collector_exceptions.rs
+++ b/src/collectors/collector_exceptions.rs
@@ -19,9 +19,9 @@ impl fmt::Display for UnableToCollectDataError {
 }
 
 impl UnableToCollectDataError {
-    pub fn abort(&self) -> ! {
-        println!("{}", self);
-        process::exit(1)
+    pub fn abort(&self, exit_code: i32) -> ! {
+        println!("{} (Error code: {})", self, exit_code);
+        process::exit(exit_code)
     }
 }
 
@@ -41,9 +41,9 @@ impl fmt::Display for InvalidNetworkInterfaceError {
 }
 
 impl InvalidNetworkInterfaceError {
-    pub fn abort(&self) -> ! {
-        println!("{}", self);
-        process::exit(1)
+    pub fn abort(&self, exit_code: i32) -> ! {
+        println!("{} (Error code: {})", self, exit_code);
+        process::exit(exit_code)
     }
 }
 

--- a/src/collectors/dmi_collector.rs
+++ b/src/collectors/dmi_collector.rs
@@ -177,7 +177,7 @@ impl DmiDecodeTable for DefaultDmiDecodeTable {
                         dmidecode_table
                     ),
                 };
-                error.panic();
+                error.abort();
             }
         };
 
@@ -232,7 +232,7 @@ impl DmiDecodeInformation for DefaultDmiDecodeInformation {
                         parameter
                     ),
                 };
-                error.panic();
+                error.abort();
             }
         };
         return String::from_utf8_lossy(&output.stdout).trim().to_string();

--- a/src/collectors/dmi_collector.rs
+++ b/src/collectors/dmi_collector.rs
@@ -177,7 +177,7 @@ impl DmiDecodeTable for DefaultDmiDecodeTable {
                         dmidecode_table
                     ),
                 };
-                error.abort();
+                error.abort(2);
             }
         };
 
@@ -232,7 +232,7 @@ impl DmiDecodeInformation for DefaultDmiDecodeInformation {
                         parameter
                     ),
                 };
-                error.abort();
+                error.abort(2);
             }
         };
         return String::from_utf8_lossy(&output.stdout).trim().to_string();

--- a/src/collectors/network_collector.rs
+++ b/src/collectors/network_collector.rs
@@ -79,7 +79,7 @@ pub fn collect_network_information(
                     message: "FATAL: Unable to collect information about network interfaces!"
                         .to_string(),
                 };
-            exc.abort();
+            exc.abort(1);
         }
     }
 }
@@ -188,7 +188,7 @@ pub fn construct_network_information(
                 let exc = collector_exceptions::InvalidNetworkInterfaceError {
                     message: "FATAL: A Network interface cannot be recognized!".to_string(),
                 };
-                exc.abort();
+                exc.abort(2);
             }
         }
         if !check_for_physical_nw(&network_information.name) {

--- a/src/collectors/network_collector.rs
+++ b/src/collectors/network_collector.rs
@@ -79,7 +79,7 @@ pub fn collect_network_information(
                     message: "FATAL: Unable to collect information about network interfaces!"
                         .to_string(),
                 };
-            exc.abort(1);
+            exc.abort(20);
         }
     }
 }
@@ -188,7 +188,7 @@ pub fn construct_network_information(
                 let exc = collector_exceptions::InvalidNetworkInterfaceError {
                     message: "FATAL: A Network interface cannot be recognized!".to_string(),
                 };
-                exc.abort(2);
+                exc.abort(25);
             }
         }
         if !check_for_physical_nw(&network_information.name) {

--- a/src/collectors/network_collector.rs
+++ b/src/collectors/network_collector.rs
@@ -79,7 +79,7 @@ pub fn collect_network_information(
                     message: "FATAL: Unable to collect information about network interfaces!"
                         .to_string(),
                 };
-            exc.panic();
+            exc.abort();
         }
     }
 }
@@ -188,7 +188,7 @@ pub fn construct_network_information(
                 let exc = collector_exceptions::InvalidNetworkInterfaceError {
                     message: "FATAL: A Network interface cannot be recognized!".to_string(),
                 };
-                exc.panic();
+                exc.abort();
             }
         }
         if !check_for_physical_nw(&network_information.name) {
@@ -275,7 +275,7 @@ fn build_interface_file_from_name(interface_name: &str) -> Result<std::fs::File,
         }
         Err(_) => {
             return Err(format!(
-                "WARNING: Speed file for interface '{}' does not exist.",
+                "\x1b[33mWARNING:\x1b[0m Speed file for interface '{}' does not exist.",
                 interface_name
             ))
         }
@@ -301,14 +301,14 @@ fn collect_interface_speed(interface_name: &str, mut input: impl Read) -> Result
     match input.read_to_string(&mut network_speed) {
         Ok(_) => {}
         Err(err) => {
-            return Err(format!("WARNING: Unable to open speed file for interface '{}'. This may happen for the loopback or wireless devices. ({}))", interface_name, err));
+            return Err(format!("\x1b[33mWARNING:\x1b[0m Unable to open speed file for interface '{}'. This may happen for the loopback or wireless devices. ({}))", interface_name, err));
         }
     };
     network_speed = network_speed.trim().replace("\n", "");
 
     if network_speed == "-1" {
         return Err(format!(
-            "INFO: No interface speed known for '{}'. The interface might be disabled.",
+            "\x1b[36mInfo:\x1b[0m No interface speed known for '{}'. The interface might be disabled.",
             interface_name
         ));
     }
@@ -444,7 +444,7 @@ mod network_collector_tests {
         assert_eq!(
             result,
             Err(format!(
-                "INFO: No interface speed known for '{}'. The interface might be disabled.",
+                "\x1b[36mInfo:\x1b[0m No interface speed known for '{}'. The interface might be disabled.",
                 interface_name
             )),
             "Test Scenario Failed (2): No error was raised by collect_interface_speed when passing speed = -1. The function did not identify the interface as disabled!"

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,2 +1,2 @@
-pub mod config_exceptions;
+mod config_exceptions;
 pub mod config_parser;

--- a/src/configuration/config_exceptions.rs
+++ b/src/configuration/config_exceptions.rs
@@ -1,6 +1,26 @@
-//! ## Config Exception Module
+//! # Config Exception Module
 //!
 //! This module provides custom exception to the config parser.
+//!
+//! ## Custom Error Codes
+//!
+//! We use custom error codes in our code to help identifying possible problems.
+//!
+//! The config module uses error codes in the range of 10 - 19.
+//!
+//! |Code  |Name       |Explanation|
+//! |------|-----------|-----------|
+//! |`10`  |||
+//! |`11`  |||
+//! |`12`  |||
+//! |`13`  |||
+//! |`14`  |||
+//! |`15`  |||
+//! |`16`  |||
+//! |`17`  |||
+//! |`18`  |||
+//! |`19`  |||
+//!
 use std::{fmt, process};
 
 /// This error is raised when the program cannot create a config file.

--- a/src/configuration/config_exceptions.rs
+++ b/src/configuration/config_exceptions.rs
@@ -1,7 +1,7 @@
 //! ## Config Exception Module
 //!
 //! This module provides custom exception to the config parser.
-use std::fmt;
+use std::{fmt, process};
 
 /// This error is raised when the program cannot create a config file.
 ///
@@ -17,8 +17,9 @@ impl fmt::Display for UnableToCreateConfigError {
 }
 
 impl UnableToCreateConfigError {
-    pub fn panic(&self) -> ! {
-        panic!("{}", self)
+    pub fn abort(&self) -> ! {
+        println!("{}", self);
+        process::exit(1)
     }
 }
 
@@ -52,8 +53,9 @@ impl fmt::Display for UnableToReadConfigError {
 }
 
 impl UnableToReadConfigError {
-    pub fn panic(&self) -> ! {
-        panic!("{}", self)
+    pub fn abort(&self) -> ! {
+        println!("{}", self);
+        process::exit(1)
     }
 }
 
@@ -75,8 +77,9 @@ impl fmt::Display for NoConfigFileError {
 }
 
 impl NoConfigFileError {
-    pub fn panic(&self) -> ! {
-        panic!("{}", self)
+    pub fn abort(&self) -> ! {
+        println!("{}", self);
+        process::exit(1)
     }
 }
 
@@ -97,7 +100,25 @@ impl fmt::Display for InvalidConfigFileError {
 }
 
 impl InvalidConfigFileError {
-    pub fn panic(&self) -> ! {
-        panic!("{}", self)
+    pub fn abort(&self) -> ! {
+        println!("{}", self);
+        process::exit(1)
+    }
+}
+
+pub struct NoConfigError {
+    pub message: String,
+}
+
+impl fmt::Display for NoConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl NoConfigError {
+    pub fn abort(&self) -> ! {
+        println!("{}", self);
+        process::exit(1);
     }
 }

--- a/src/configuration/config_exceptions.rs
+++ b/src/configuration/config_exceptions.rs
@@ -8,18 +8,18 @@
 //!
 //! The config module uses error codes in the range of 10 - 19.
 //!
-//! |Code  |Name             |Explanation                                            |
-//! |------|-----------------|-------------------------------------------------------|
-//! |`10`  |Permission Denied|Unable to create config file on system.                |
-//! |`11`  |Emtpy Config File|Default config file was created but not parameters set.|
-//! |`12`  |||
-//! |`13`  |||
-//! |`14`  |||
-//! |`15`  |||
-//! |`16`  |||
-//! |`17`  |||
-//! |`18`  |||
-//! |`19`  |||
+//! |Code  |Name              |Explanation                                                |
+//! |------|------------------|-----------------------------------------------------------|
+//! |`10`  |PermissionDenied  |Unable to create config file on system.                    |
+//! |`11`  |EmptyConfigFile   |Default config file was created but not parameters set.    |
+//! |`12`  |UnableToInitConfig|An error occurred while trying to initialize config file.  |
+//! |`13`  |ConfigWriteError  |An error occurred while trying to write to the config file.|
+//! |`14`  |ConfigReadError   |Unable to read configuration file.                         |
+//! |`15`  |TomlSyntaxError   |Your TOML is not valid. Please check for syntax errors.    |
+//! |`16`  |--Undefined--     |--Undefined--|
+//! |`17`  |--Undefined--     |--Undefined--|
+//! |`18`  |--Undefined--     |--Undefined--|
+//! |`19`  |--Undefined--     |--Undefined--|
 //!
 use std::{fmt, process};
 

--- a/src/configuration/config_exceptions.rs
+++ b/src/configuration/config_exceptions.rs
@@ -17,9 +17,9 @@ impl fmt::Display for UnableToCreateConfigError {
 }
 
 impl UnableToCreateConfigError {
-    pub fn abort(&self) -> ! {
-        println!("{}", self);
-        process::exit(1)
+    pub fn abort(&self, exit_code: i32) -> ! {
+        println!("{} (Error code: {})", self, exit_code);
+        process::exit(exit_code)
     }
 }
 
@@ -37,11 +37,6 @@ impl fmt::Display for ConfigWriteException {
 }
 
 /// This error is raised when the config fil cannot be read for an unknown reason.
-///
-/// # Panics
-///
-/// When the config file cannot be read, the config parameters cannot be loaded therefore
-/// the program panics.
 pub struct UnableToReadConfigError {
     pub message: String,
 }
@@ -53,19 +48,15 @@ impl fmt::Display for UnableToReadConfigError {
 }
 
 impl UnableToReadConfigError {
-    pub fn abort(&self) -> ! {
-        println!("{}", self);
-        process::exit(1)
+    pub fn abort(&self, exit_code: i32) -> ! {
+        println!("{} (Error code: {})", self, exit_code);
+        process::exit(exit_code)
     }
 }
 
 /// This error is raised when the configuration file is not found.
 ///
 /// This error is unrecoverable.
-///
-/// # Panics
-///
-/// If no configuration file is present when validating config, the program panics.
 pub struct NoConfigFileError {
     pub message: String,
 }
@@ -77,18 +68,14 @@ impl fmt::Display for NoConfigFileError {
 }
 
 impl NoConfigFileError {
-    pub fn abort(&self) -> ! {
-        println!("{}", self);
-        process::exit(1)
+    pub fn abort(&self, exit_code: i32) -> ! {
+        println!("{} (Error code: {})", self, exit_code);
+        process::exit(exit_code)
     }
 }
 
 /// If the config file does not have valid syntax, the program mus abort and prompt
 /// the user to fix it.
-///
-/// # Panics
-///
-/// Causes the program to panic when the config file does not have valid toml syntax.
 pub struct InvalidConfigFileError {
     pub message: String,
 }
@@ -100,12 +87,13 @@ impl fmt::Display for InvalidConfigFileError {
 }
 
 impl InvalidConfigFileError {
-    pub fn abort(&self) -> ! {
-        println!("{}", self);
-        process::exit(1)
+    pub fn abort(&self, exit_code: i32) -> ! {
+        println!("{} (Error code: {})", self, exit_code);
+        process::exit(exit_code)
     }
 }
 
+/// If the config file is empty or contains empty fields, and no CLI parameters are given, this error shall be raised.
 pub struct NoConfigError {
     pub message: String,
 }
@@ -117,8 +105,8 @@ impl fmt::Display for NoConfigError {
 }
 
 impl NoConfigError {
-    pub fn abort(&self) -> ! {
-        println!("{}", self);
-        process::exit(1);
+    pub fn abort(&self, exit_code: i32) -> ! {
+        println!("{} (Error code: {})", self, exit_code);
+        process::exit(exit_code)
     }
 }

--- a/src/configuration/config_exceptions.rs
+++ b/src/configuration/config_exceptions.rs
@@ -8,10 +8,10 @@
 //!
 //! The config module uses error codes in the range of 10 - 19.
 //!
-//! |Code  |Name       |Explanation|
-//! |------|-----------|-----------|
-//! |`10`  |||
-//! |`11`  |||
+//! |Code  |Name             |Explanation                                            |
+//! |------|-----------------|-------------------------------------------------------|
+//! |`10`  |Permission Denied|Unable to create config file on system.                |
+//! |`11`  |Emtpy Config File|Default config file was created but not parameters set.|
 //! |`12`  |||
 //! |`13`  |||
 //! |`14`  |||

--- a/src/configuration/config_parser.rs
+++ b/src/configuration/config_parser.rs
@@ -94,7 +94,7 @@ pub fn set_up_configuration(
                 message: "\x1b[31mFATAL:\x1b[0m An error occurred while initializing the config!"
                     .to_string(),
             };
-            err.abort(1)
+            err.abort(12)
         }
     }
 
@@ -102,7 +102,7 @@ pub fn set_up_configuration(
         let err = config_exceptions::NoConfigError {
             message: "\x1b[31mFATAL:\x1b[0m No configuration parameters found in CLI while using an empty config file!\nPlease enter valid configuration parameters in the configuration file or provide them via the CLI.".to_string()
         };
-        err.abort(5)
+        err.abort(11)
     }
 
     conf_data = ConfigData::read_config_file();
@@ -145,6 +145,10 @@ fn file_exists(path: &Path) -> bool {
 /// # Returns
 ///
 /// * `config_file_path: PathBuf` - The directory the config file is located (~/.nbs-config.toml)
+///
+/// # Panics
+///
+/// This function panics if no `$XDF_CONFIG_HOME` variable can be found.
 fn get_config_dir() -> PathBuf {
     let home_dir: String = match std::env::var("HOME") {
         Ok(val) => val,
@@ -214,7 +218,7 @@ impl ConfigData {
                         err
                     ),
                 };
-                exc.abort(5);
+                exc.abort(10);
             }
         };
 
@@ -228,7 +232,7 @@ impl ConfigData {
                         err
                     ),
                 };
-                exc.abort(5);
+                exc.abort(13);
             }
         }
         Ok(())
@@ -255,7 +259,7 @@ impl ConfigData {
                 let exc: UnableToReadConfigError = config_exceptions::UnableToReadConfigError {
                     message: format!("x1b[31mFATAL:x1b[0m Unable to open config file! {}", err),
                 };
-                exc.abort(5)
+                exc.abort(14)
             }
         };
 
@@ -265,7 +269,7 @@ impl ConfigData {
                 let exc: InvalidConfigFileError = config_exceptions::InvalidConfigFileError {
                     message: format!("\x1b[31mFATAL:\x1b[0m Invalid config file syntax! Make sure the configuration file has valid TOML syntax. ({})", err),
                 };
-                exc.abort(5)
+                exc.abort(15)
             }
         };
 
@@ -324,7 +328,7 @@ impl ConfigData {
                 let exc: UnableToReadConfigError = config_exceptions::UnableToReadConfigError {
                     message: format!("x1b[31mFATAL:x1b[0m Unable to open config file! {}", err),
                 };
-                exc.abort(5)
+                exc.abort(14)
             }
         };
 
@@ -334,7 +338,7 @@ impl ConfigData {
                 let exc: InvalidConfigFileError = config_exceptions::InvalidConfigFileError {
                     message: format!("\x1b[31mFATAL:\x1b[0m Invalid config file syntax! Make sure the configuration file has valid TOML syntax. ({})", err),
                 };
-                exc.abort(5)
+                exc.abort(15)
             }
         };
 

--- a/src/configuration/config_parser.rs
+++ b/src/configuration/config_parser.rs
@@ -62,7 +62,7 @@ pub fn set_up_configuration(
         // TODO Rewrite validation logic to properly condition here
         match ConfigData::validate_config_file() {
             Ok(_) => {
-                println!("Configuration file valid. Loading defaults...");
+                println!("Configuration file \x1b[32mvalid\x1b[0m. Loading defaults...");
                 conf_data = ConfigData::read_config_file();
 
                 if uri.is_some() {
@@ -90,15 +90,19 @@ pub fn set_up_configuration(
             println!("\x1b[32mDefault configuration file created successfully.\x1b[0m")
         }
         Err(_) => {
-            panic!("FATAL: An error occurred while initializing the config!")
+            let err = config_exceptions::UnableToCreateConfigError {
+                message: "\x1b[31mFATAL:\x1b[0m An error occurred while initializing the config!"
+                    .to_string(),
+            };
+            err.abort()
         }
     }
 
     if uri.is_none() || token.is_none() {
-        panic!(
-            "FATAL: No configuration parameters found in CLI while using an empty config file!\n
-            Please enter valid configuration parameters in the configuration file or provide them via the CLI."
-        )
+        let err = config_exceptions::NoConfigError {
+            message: "\x1b[31mFATAL:\x1b[0m No configuration parameters found in CLI while using an empty config file!\nPlease enter valid configuration parameters in the configuration file or provide them via the CLI.".to_string()
+        };
+        err.abort()
     }
 
     conf_data = ConfigData::read_config_file();
@@ -205,9 +209,12 @@ impl ConfigData {
             Ok(file) => file,
             Err(err) => {
                 let exc: UnableToCreateConfigError = config_exceptions::UnableToCreateConfigError {
-                    message: format!("FATAL: Unable to create config file! ({})", err),
+                    message: format!(
+                        "\x1b[31mFATAL:\x1b[0m Unable to create config file! ({})",
+                        err
+                    ),
                 };
-                exc.panic();
+                exc.abort();
             }
         };
 
@@ -216,9 +223,12 @@ impl ConfigData {
             Ok(_) => {}
             Err(err) => {
                 let exc: UnableToCreateConfigError = config_exceptions::UnableToCreateConfigError {
-                    message: format!("FATAL: Unable to write defaults to config file! ({})", err),
+                    message: format!(
+                        "\x1b[31mFATAL:\x1b[0m Unable to write defaults to config file! ({})",
+                        err
+                    ),
                 };
-                exc.panic();
+                exc.abort();
             }
         }
         Ok(())
@@ -245,7 +255,7 @@ impl ConfigData {
                 let exc: UnableToReadConfigError = config_exceptions::UnableToReadConfigError {
                     message: format!("x1b[31mFATAL:x1b[0m Unable to open config file! {}", err),
                 };
-                exc.panic()
+                exc.abort()
             }
         };
 
@@ -255,7 +265,7 @@ impl ConfigData {
                 let exc: InvalidConfigFileError = config_exceptions::InvalidConfigFileError {
                     message: format!("\x1b[31mFATAL:\x1b[0m Invalid config file syntax! Make sure the configuration file has valid TOML syntax. ({})", err),
                 };
-                exc.panic()
+                exc.abort()
             }
         };
 
@@ -279,21 +289,21 @@ impl ConfigData {
 
         if config_parameters.netbox_uri.is_empty() {
             return Err(
-                "Error: Config parameter 'netbox_uri' is empty! This parameter is mandatory."
+                "\x1b[31mValidation Error:\x1b[0m Config parameter 'netbox_uri' is empty! This parameter is mandatory."
                     .to_string(),
             );
         }
 
         if config_parameters.netbox_api_token.is_empty() {
             return Err(
-                "Error: Config parameter 'netbox_api_token' is empty! This parameter is mandatory."
+                "\x1b[34mValidation Error:\x1b[0m Config parameter 'netbox_api_token' is empty! This parameter is mandatory."
                     .to_string(),
             );
         }
 
         if config_parameters.system_location.is_empty() {
             return Err(
-                "Error: Config parameter 'system_location' is empty! This parameter is mandatory."
+                "\x1b[34mValidation Error:\x1b[0m Config parameter 'system_location' is empty! This parameter is mandatory."
                     .to_string(),
             );
         }
@@ -314,7 +324,7 @@ impl ConfigData {
                 let exc: UnableToReadConfigError = config_exceptions::UnableToReadConfigError {
                     message: format!("x1b[31mFATAL:x1b[0m Unable to open config file! {}", err),
                 };
-                exc.panic()
+                exc.abort()
             }
         };
 
@@ -324,7 +334,7 @@ impl ConfigData {
                 let exc: InvalidConfigFileError = config_exceptions::InvalidConfigFileError {
                     message: format!("\x1b[31mFATAL:\x1b[0m Invalid config file syntax! Make sure the configuration file has valid TOML syntax. ({})", err),
                 };
-                exc.panic()
+                exc.abort()
             }
         };
 

--- a/src/configuration/config_parser.rs
+++ b/src/configuration/config_parser.rs
@@ -94,7 +94,7 @@ pub fn set_up_configuration(
                 message: "\x1b[31mFATAL:\x1b[0m An error occurred while initializing the config!"
                     .to_string(),
             };
-            err.abort()
+            err.abort(1)
         }
     }
 
@@ -102,7 +102,7 @@ pub fn set_up_configuration(
         let err = config_exceptions::NoConfigError {
             message: "\x1b[31mFATAL:\x1b[0m No configuration parameters found in CLI while using an empty config file!\nPlease enter valid configuration parameters in the configuration file or provide them via the CLI.".to_string()
         };
-        err.abort()
+        err.abort(5)
     }
 
     conf_data = ConfigData::read_config_file();
@@ -214,7 +214,7 @@ impl ConfigData {
                         err
                     ),
                 };
-                exc.abort();
+                exc.abort(5);
             }
         };
 
@@ -228,7 +228,7 @@ impl ConfigData {
                         err
                     ),
                 };
-                exc.abort();
+                exc.abort(5);
             }
         }
         Ok(())
@@ -255,7 +255,7 @@ impl ConfigData {
                 let exc: UnableToReadConfigError = config_exceptions::UnableToReadConfigError {
                     message: format!("x1b[31mFATAL:x1b[0m Unable to open config file! {}", err),
                 };
-                exc.abort()
+                exc.abort(5)
             }
         };
 
@@ -265,7 +265,7 @@ impl ConfigData {
                 let exc: InvalidConfigFileError = config_exceptions::InvalidConfigFileError {
                     message: format!("\x1b[31mFATAL:\x1b[0m Invalid config file syntax! Make sure the configuration file has valid TOML syntax. ({})", err),
                 };
-                exc.abort()
+                exc.abort(5)
             }
         };
 
@@ -324,7 +324,7 @@ impl ConfigData {
                 let exc: UnableToReadConfigError = config_exceptions::UnableToReadConfigError {
                     message: format!("x1b[31mFATAL:x1b[0m Unable to open config file! {}", err),
                 };
-                exc.abort()
+                exc.abort(5)
             }
         };
 
@@ -334,7 +334,7 @@ impl ConfigData {
                 let exc: InvalidConfigFileError = config_exceptions::InvalidConfigFileError {
                     message: format!("\x1b[31mFATAL:\x1b[0m Invalid config file syntax! Make sure the configuration file has valid TOML syntax. ({})", err),
                 };
-                exc.abort()
+                exc.abort(5)
             }
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ pub mod configuration;
 use clap::Parser;
 use collectors::{dmi_collector, network_collector};
 use configuration::config_parser::set_up_configuration;
+use std::process;
 
 /// The arguments that netbox-sync expects to get via the cli.
 ///
@@ -50,7 +51,8 @@ fn main() {
     let config = match set_up_configuration(args.uri, args.token, args.location) {
         Ok(conf) => conf,
         Err(err) => {
-            panic!("{}", err)
+            println!("{}", err);
+            process::exit(1)
         }
     };
 


### PR DESCRIPTION
# What does this PR change?

<!-- provide a short description what exactly your PR changes here -->

Custom error types used to `panic!` upon encountering a unrecoverable error leading to an ugly error message.

I believe that users should never be faced with a `panic!`, as long as they can fix the problem (e.g missing config parameters, unreachable netbox instance, wrong usage, etc.)

`panic!` should only be used to abort the program on internal and unpredictable errors.

This PR changes the custom `panic` method of the error types to be an `abort()` function, which prints the error message and then calls `process::exit(<EXIT_CODE>)` with the exit code `EXIT_CODE` indicating the error via a custom exit code.
These exit codes will be documented and will have certain kinds of exceptions assigned to help with troubleshooting.

- [x] Implement graceful exit for errors
- [x] Introduce and document custom exit codes

Tick the applicable box:
- [ ] Add new feature
- [ ] Security changes
- [ ] Tests
- [ ] Documentation changed
- [x] Behaviour change
<br/>

- [ ] General Maintenance

## Links

<!-- In case your changes fix an existing issue please link it below: -->

Fixes: n/A

- [x] DONE

## Documentation

<!-- provide description about documentation done here or remove this line -->

- No documentation needed
<br/>

- [x] DONE