### PR TITLE
[CONFIG] Add mandatory fields

### DIFF
--- a/src/configuration/config_parser.rs
+++ b/src/configuration/config_parser.rs
@@ -27,7 +27,9 @@ use super::config_exceptions::{self, *};
 pub struct ConfigData {
     netbox_api_token: String,
     netbox_uri: String,
+    name: String,
     system_location: String,
+    device_role: String,
 }
 
 /// Set up configuration
@@ -51,7 +53,9 @@ pub struct ConfigData {
 pub fn set_up_configuration(
     uri: Option<String>,
     token: Option<String>,
+    name: Option<String>,
     location: Option<String>,
+    device_role: Option<String>,
 ) -> Result<ConfigData, String> {
     let mut conf_data: ConfigData;
 
@@ -73,8 +77,16 @@ pub fn set_up_configuration(
                     conf_data.netbox_api_token = token.unwrap();
                 }
 
+                if name.is_some() {
+                    conf_data.name = name.unwrap();
+                }
+
                 if location.is_some() {
                     conf_data.system_location = location.unwrap();
+                }
+
+                if device_role.is_some() {
+                    conf_data.device_role = device_role.unwrap();
                 }
 
                 return Ok(conf_data);
@@ -110,7 +122,9 @@ pub fn set_up_configuration(
     if uri.is_some() && token.is_some() && location.is_some() {
         conf_data.netbox_uri = uri.unwrap();
         conf_data.netbox_api_token = token.unwrap();
+        conf_data.name = name.unwrap();
         conf_data.system_location = location.unwrap();
+        conf_data.device_role = device_role.unwrap();
     }
 
     println!("\x1b[32mConfiguration loaded.\x1b[0m");
@@ -190,8 +204,10 @@ impl ConfigData {
 
         let system_section: toml::map::Map<String, Value> = {
             let mut system_config_table: toml::map::Map<String, Value> = toml::value::Table::new();
+            system_config_table.insert("name".to_string(), Value::String("".to_string()));
             system_config_table
                 .insert("system_location".to_string(), Value::String("".to_string()));
+            system_config_table.insert("device_role".to_string(), Value::String("".to_string()));
             system_config_table
         };
 
@@ -284,7 +300,17 @@ impl ConfigData {
                 .unwrap()
                 .trim()
                 .to_string(),
+            name: config_contents["system"]["name"]
+                .as_str()
+                .unwrap()
+                .trim()
+                .to_string(),
             system_location: config_contents["system"]["system_location"]
+                .as_str()
+                .unwrap()
+                .trim()
+                .to_string(),
+            device_role: config_contents["system"]["device_role"]
                 .as_str()
                 .unwrap()
                 .trim()
@@ -305,9 +331,23 @@ impl ConfigData {
             );
         }
 
+        if config_parameters.name.is_empty() {
+            return Err(
+                "\x1b[34mValidation Error:\x1b[0m Config parameter 'name' is empty! This parameter is mandatory."
+                    .to_string(),
+            );
+        }
+
         if config_parameters.system_location.is_empty() {
             return Err(
                 "\x1b[34mValidation Error:\x1b[0m Config parameter 'system_location' is empty! This parameter is mandatory."
+                    .to_string(),
+            );
+        }
+
+        if config_parameters.device_role.is_empty() {
+            return Err(
+                "\x1b[34mValidation Error:\x1b[0m Config parameter 'device_role' is empty! This parameter is mandatory."
                     .to_string(),
             );
         }
@@ -353,7 +393,17 @@ impl ConfigData {
                 .unwrap()
                 .trim()
                 .to_string(),
+            name: config_content["system"]["name"]
+                .as_str()
+                .unwrap()
+                .trim()
+                .to_string(),
             system_location: config_content["system"]["system_location"]
+                .as_str()
+                .unwrap()
+                .trim()
+                .to_string(),
+            device_role: config_content["system"]["device_role"]
                 .as_str()
                 .unwrap()
                 .trim()

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,9 @@ use std::process;
 ///
 /// * `uri: String` - The URI to your Netbox instance.
 /// * `token: String` - The authentication token for the netbox URI.
+/// * `name: String` - The name of the device
+/// * `location: String` - The location of the device
+/// * `device_role: String` - The type of device (server, router, etc.)
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about=None)]
 struct Args {
@@ -31,9 +34,17 @@ struct Args {
     #[arg(short, long)]
     token: Option<String>,
 
+    /// The name of the device
+    #[arg(short, long)]
+    name: Option<String>,
+
     /// The location of the machine (must be one of the locations you have set as available in your Netbox instance)
     #[arg(short, long)]
     location: Option<String>,
+
+    /// The role of the machine (switch, server, router, etc.)
+    #[arg(short, long)]
+    device_role: Option<String>,
 }
 
 fn main() {
@@ -48,7 +59,13 @@ fn main() {
 
     println!("{:#?}", output2);
 
-    let config = match set_up_configuration(args.uri, args.token, args.location) {
+    let config = match set_up_configuration(
+        args.uri,
+        args.token,
+        args.name,
+        args.location,
+        args.device_role,
+    ) {
         Ok(conf) => conf,
         Err(err) => {
             println!("{}", err);


### PR DESCRIPTION
# What does this PR change?

For the Netbox API to accept a newly registered machine there are some fields which are mandatory.

- Device Name
- Device Role (Use of the device)
- Site (location)

These have been added in this PR

<!-- provide a short description what exactly your PR changes here -->

Tick the applicable box:
- [x] Add new feature
- [ ] Security changes
- [ ] Tests
- [ ] Documentation changed
<br/>

- [ ] General Maintenance

## Links

<!-- In case your changes fix an existing issue please link it below: -->

Fixes:

- [ ] DONE

## Documentation

<!-- provide description about documentation done here or remove this line -->

- No documentation needed
<br/>

- [ ] DONE